### PR TITLE
INTYGFV-12486: New patient id (alternativeSsn) should always be displayed, but only persisted if the user is authorized to edit a draft.

### DIFF
--- a/web/src/main/resources/META-INF/resources/webjars/common/webcert/components/wcNewPersonIdMessage/wcNewPersonIdMessage.directive.js
+++ b/web/src/main/resources/META-INF/resources/webjars/common/webcert/components/wcNewPersonIdMessage/wcNewPersonIdMessage.directive.js
@@ -28,8 +28,7 @@ angular.module('common').directive('wcNewPersonIdMessage', [
         return {
             restrict: 'E',
             scope: {
-                patient: '=',
-                isIntyg: '='
+                patient: '='
             },
             controller: function($scope) {
 
@@ -71,7 +70,15 @@ angular.module('common').directive('wcNewPersonIdMessage', [
                     }
                 }
 
-                if ($scope.isIntyg) {
+                var beforeAlternateSsn = UserModel.getIntegrationParam('beforeAlternateSsn');
+                if (!ObjectHelper.isEmpty(beforeAlternateSsn)) {
+                    $scope.show = false;
+                    var alternatePatientSSn = UserModel.getIntegrationParam('alternateSsn');
+                    var intygPersonnummer = beforeAlternateSsn;
+                    if (!ObjectHelper.isEmpty(alternatePatientSSn)) {
+                        decideMessageToShow(intygPersonnummer, alternatePatientSSn);
+                    }
+                } else {
                     var updateShowFlag = function(currentPatient) {
                         $scope.show = false;
                         var alternatePatientSSn = UserModel.getIntegrationParam('alternateSsn');
@@ -84,14 +91,6 @@ angular.module('common').directive('wcNewPersonIdMessage', [
                     // Patient comes from intyg which is loaded async
                     $scope.$watch('patient', updateShowFlag, true);
                     updateShowFlag();
-                }
-                else {
-                    $scope.show = false;
-                    var alternatePatientSSn = UserModel.getIntegrationParam('alternateSsn');
-                    var intygPersonnummer = UserModel.getIntegrationParam('beforeAlternateSsn');
-                    if (!ObjectHelper.isEmpty(alternatePatientSSn) && !ObjectHelper.isEmpty(intygPersonnummer)) {
-                        decideMessageToShow(intygPersonnummer, alternatePatientSSn);
-                    }
                 }
 
                 $scope.openModal = function() {

--- a/web/src/main/resources/META-INF/resources/webjars/common/webcert/components/wcPatientStatus/wcPatientStatus.directive.html
+++ b/web/src/main/resources/META-INF/resources/webjars/common/webcert/components/wcPatientStatus/wcPatientStatus.directive.html
@@ -1,6 +1,6 @@
 <div class="wc-patient-status-container">
   <wc-sekretess-avliden uuid="patient.personId" avliden="patient.avliden" sekretessmarkering="patient.sekretessmarkering"></wc-sekretess-avliden>
-  <wc-new-person-id-message patient="patient" is-intyg="isIntyg"></wc-new-person-id-message>
+  <wc-new-person-id-message patient="patient"></wc-new-person-id-message>
   <wc-patient-info-change-message intyg="intygModel" intyg-properties="intygProperties" is-intyg="isIntyg"></wc-patient-info-change-message>
   <wc-patient-address-missing-from-integration-message intyg="intygModel" is-intyg="isIntyg"></wc-patient-address-missing-from-integration-message>
 </div>

--- a/web/src/main/resources/META-INF/resources/webjars/common/webcert/utkast/utkastHeader/wcUtkastHeader/wcUtkastHeader.directive.js
+++ b/web/src/main/resources/META-INF/resources/webjars/common/webcert/utkast/utkastHeader/wcUtkastHeader/wcUtkastHeader.directive.js
@@ -16,22 +16,38 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-angular.module('common').directive('wcUtkastHeader', [ '$window', '$state', 'common.moduleService', 'common.UtkastHeaderViewState', 'common.UserModel',
-    function($window, $state, moduleService, UtkastHeaderViewState, UserModel) {
-    'use strict';
+angular.module('common').directive('wcUtkastHeader',
+    ['$window', '$state', 'common.moduleService', 'common.UtkastHeaderViewState', 'common.UserModel',
+      function($window, $state, moduleService, UtkastHeaderViewState, UserModel) {
+        'use strict';
 
-    return {
-        restrict: 'E',
-        scope: {
+        return {
+          restrict: 'E',
+          scope: {
             utkastViewState: '=',
             certForm: '='
-        },
-        templateUrl: '/web/webjars/common/webcert/utkast/utkastHeader/wcUtkastHeader/wcUtkastHeader.directive.html',
-        link: function($scope) {
+          },
+          templateUrl: '/web/webjars/common/webcert/utkast/utkastHeader/wcUtkastHeader/wcUtkastHeader.directive.html',
+          link: function($scope) {
 
             $scope.certificateName = moduleService.getModuleName(UtkastHeaderViewState.intygType);
             $scope.backState = 'webcert.create-choose-certtype-index';
-            $scope.oldPersonId = UserModel.getIntegrationParam('beforeAlternateSsn');
-        }
-    };
-} ]);
+
+            // $scope.oldPersonId = UserModel.getIntegrationParam('beforeAlternateSsn');
+
+            function updatePersonId() {
+              var beforeAlternateSsn = UserModel.getIntegrationParam('beforeAlternateSsn');
+              if (beforeAlternateSsn) {
+                $scope.oldPersonId = beforeAlternateSsn;
+                $scope.personId = UserModel.getIntegrationParam('alternateSsn');
+              } else if (UserModel.getIntegrationParam('alternateSsn')) {
+                $scope.oldPersonId = $scope.personId;
+                $scope.personId = UserModel.getIntegrationParam('alternateSsn');
+              }
+            }
+
+            updatePersonId();
+            $scope.$on('intyg.loaded', updatePersonId);
+          }
+        };
+      }]);


### PR DESCRIPTION
Changes are made in Webcert and Infra as well.