### PR TITLE
INTYGFV-12528: Changed so front end sends the sick leave periods to b…

### DIFF
--- a/web/src/main/resources/META-INF/resources/webjars/common/webcert/utkast/unified-edit/components/ueSjukfranvaro/sjukfranvaro.viewstate.service.js
+++ b/web/src/main/resources/META-INF/resources/webjars/common/webcert/utkast/unified-edit/components/ueSjukfranvaro/sjukfranvaro.viewstate.service.js
@@ -76,7 +76,7 @@ angular.module('common').service('common.SjukfranvaroViewStateService',
 
             this.updatePeriods = function() {
 
-                var minDate, maxDate;
+                var calculateTotalDays = 0;
 
                 angular.forEach(this.model, function(value) {
 
@@ -88,29 +88,21 @@ angular.module('common').service('common.SjukfranvaroViewStateService',
                     var fromMoment = DateUtilsService.convertDateStrict(value.period.from);
                     var toMoment = DateUtilsService.convertDateStrict(value.period.tom);
 
-                    // Get min and max dates
-                    if (fromMoment && (!minDate || fromMoment.isBefore(minDate))) {
-                        minDate = fromMoment;
-                    }
-                    if (toMoment && (!maxDate || toMoment.isAfter(maxDate))) {
-                        maxDate = toMoment;
-                    }
-
                     // Checkboxen för den valda sjukskrivningsgraden ska fortfarande vara ifylld och endast försvinna
                     // om man klickar ur den, eller tömmer både 'från och med' och 'till och med' datumen.
                     if (!value.period.from && !value.period.tom) {
                         value.checked = false;
                     }
+
+                    if (fromMoment && toMoment) {
+                        calculateTotalDays += toMoment.diff(fromMoment, 'days') + 1;
+                    }
                 }, this);
 
                 this.totalDays = undefined;
-                if (minDate && maxDate) {
-                    this.totalDays = maxDate.diff(minDate, 'days') + 1;
-                    if (this.totalDays <= 0) {
-                        this.totalDays = undefined;
-                    }
+                if (calculateTotalDays) {
+                    this.totalDays = calculateTotalDays;
                 }
-
             };
 
             this.addRow = function () {

--- a/web/src/main/resources/META-INF/resources/webjars/common/webcert/utkast/unified-edit/components/ueSjukskrivningar/fmbVarning.directive.html
+++ b/web/src/main/resources/META-INF/resources/webjars/common/webcert/utkast/unified-edit/components/ueSjukskrivningar/fmbVarning.directive.html
@@ -1,6 +1,5 @@
 <div class="fmb-varning">
-    <!-- Warning deactivated. false was: fmbVarning.overskriderRekommenderadSjukskrivningstid -->
-    <wc-alert-message ng-if="false" alert-severity="warning">
+    <wc-alert-message ng-if="fmbVarning.overskriderRekommenderadSjukskrivningstid" alert-severity="warning">
       {{fmbVarning.text}}
     </wc-alert-message>
     <wc-alert-message ng-if="fmbVarning.error" alert-severity="warning">

--- a/web/src/main/resources/META-INF/resources/webjars/common/webcert/utkast/unified-edit/components/ueSjukskrivningar/sjukskrivningar.viewstate.service.js
+++ b/web/src/main/resources/META-INF/resources/webjars/common/webcert/utkast/unified-edit/components/ueSjukskrivningar/sjukskrivningar.viewstate.service.js
@@ -121,7 +121,7 @@ angular.module('common').service('common.SjukskrivningarViewStateService',
 
             this.updatePeriods = function() {
 
-                var minDate, maxDate;
+                var calculateTotalDays = 0;
 
                 angular.forEach(this.model, function(value, key) {
 
@@ -133,18 +133,14 @@ angular.module('common').service('common.SjukskrivningarViewStateService',
                     var fromMoment = DateUtilsService.convertDateStrict(value.period.from);
                     var toMoment = DateUtilsService.convertDateStrict(value.period.tom);
 
-                    // Get min and max dates
-                    if (fromMoment && (!minDate || fromMoment.isBefore(minDate))) {
-                        minDate = fromMoment;
-                    }
-                    if (toMoment && (!maxDate || toMoment.isAfter(maxDate))) {
-                        maxDate = toMoment;
-                    }
-
                     // Checkboxen för den valda sjukskrivningsgraden ska fortfarande vara ifylld och endast försvinna
                     // om man klickar ur den, eller tömmer både 'från och med' och 'till och med' datumen.
                     if (!value.period.from && !value.period.tom) {
                         this.periods[key].checked = false;
+                    }
+
+                    if (fromMoment && toMoment) {
+                        calculateTotalDays += toMoment.diff(fromMoment, 'days') + 1;
                     }
 
                     // Uppdatera värden för arbetstid och period
@@ -152,10 +148,9 @@ angular.module('common').service('common.SjukskrivningarViewStateService',
                 }, this);
 
                 this.totalDays = undefined;
-                if (minDate && maxDate) {
-                    this.totalDays = maxDate.diff(minDate, 'days') + 1;
+                if (calculateTotalDays) {
+                    this.totalDays = calculateTotalDays;
                 }
-
             };
         }
     ]);


### PR DESCRIPTION
…ackend for consideration when evaluating FMB-warnings. This is done so the backend can consider overlaps with already issued certificates, sick leave periods in the past (back-dating certificates).