### PR TITLE
feature/INTYGFV-13201 Added possibility to view AG-certificates in Rehabstod

### DIFF
--- a/skl/ag114/src/main/resources/META-INF/resources/webjars/ag114/webcert/views/router.js
+++ b/skl/ag114/src/main/resources/META-INF/resources/webjars/ag114/webcert/views/router.js
@@ -115,5 +115,23 @@ angular.module('ag114').config(function($stateProvider) {
                     controller: 'common.IntygHeader'
                 }
             }
-        });
+        }).state('ag114-readonly', {
+        data: { intygType: 'ag114' },
+        url: '/intyg-read-only/ag114/:intygTypeVersion/:certificateId',
+        resolve: {
+            ViewState: 'ag114.IntygController.ViewStateService',
+            ViewConfigFactory: viewConfig,
+            DiagnosExtractor: function() {
+                return function (ag114Model) {
+                    return ag114Model.diagnoser[0].diagnosKod;
+                };
+            }
+        },
+        views: {
+            'content@': {
+                templateUrl: commonPath + 'intyg/read-only-view/wcIntygReadOnlyView.template.html',
+                controller: 'common.wcIntygReadOnlyViewController'
+            }
+        }
+    });
 });

--- a/skl/ag7804/src/main/resources/META-INF/resources/webjars/ag7804/webcert/views/router.js
+++ b/skl/ag7804/src/main/resources/META-INF/resources/webjars/ag7804/webcert/views/router.js
@@ -92,5 +92,24 @@ angular.module('ag7804').config(function($stateProvider) {
                     controller: 'common.IntygHeader'
                 }
             }
+        }).
+        state('ag7804-readonly', {
+            data: { intygType: 'ag7804' },
+            url: '/intyg-read-only/ag7804/:intygTypeVersion/:certificateId',
+            resolve: {
+                ViewState: 'ag7804.IntygController.ViewStateService',
+                ViewConfigFactory: viewConfig,
+                DiagnosExtractor: function() {
+                    return function (ag7804Model) {
+                        return ag7804Model.diagnoser[0].diagnosKod;
+                    };
+                }
+            },
+            views: {
+                'content@': {
+                    templateUrl: commonPath + 'intyg/read-only-view/wcIntygReadOnlyView.template.html',
+                    controller: 'common.wcIntygReadOnlyViewController'
+                }
+            }
         });
 });

--- a/web/src/main/resources/META-INF/resources/webjars/common/webcert/intyg/read-only-view/wcIntygReadOnlyView.controller.js
+++ b/web/src/main/resources/META-INF/resources/webjars/common/webcert/intyg/read-only-view/wcIntygReadOnlyView.controller.js
@@ -49,7 +49,11 @@ angular.module('common').controller(
                             });
                     }
 
-                    ViewState.common.updateIntygProperties(result, ViewState.intygModel.id);
+                    if(ViewState.intygModel) {
+                        ViewState.common.updateIntygProperties(result, ViewState.intygModel.id);
+                    } else {
+                        ViewState.common.updateIntygProperties(result, ViewState.cert.id);
+                    }
 
 
                     // Construct panel config
@@ -63,15 +67,17 @@ angular.module('common').controller(
                         }
                     };
                     //Kompletteringpanel is always enabled
-                    panelConfig.tabs.push({
-                        id: 'wc-komplettering-read-only-panel-tab',
-                        title: 'common.supportpanel.ro-kompletteringar.title',
-                        tooltip: 'common.supportpanel.ro-kompletteringar.tooltip',
-                        config: {
-                            intygContext: panelConfig.intygContext
-                        },
-                        active: true
-                    });
+                    if (ViewState.cert.typ !== 'ag114' && ViewState.cert.typ !== 'ag7804') {
+                        panelConfig.tabs.push({
+                            id: 'wc-komplettering-read-only-panel-tab',
+                            title: 'common.supportpanel.ro-kompletteringar.title',
+                            tooltip: 'common.supportpanel.ro-kompletteringar.tooltip',
+                            config: {
+                                intygContext: panelConfig.intygContext
+                            },
+                            active: true
+                        });
+                    }
                     // SRS read only view
                     if (authorityService.isAuthorityActive(
                         {feature: 'SRS', intygstyp: ViewState.common.intygProperties.type})) {

--- a/web/src/main/resources/META-INF/resources/webjars/common/webcert/intyg/read-only-view/wcIntygReadOnlyView.controller.js
+++ b/web/src/main/resources/META-INF/resources/webjars/common/webcert/intyg/read-only-view/wcIntygReadOnlyView.controller.js
@@ -66,7 +66,7 @@ angular.module('common').controller(
                             intygTypeVersion: $scope.viewState.cert.textVersion
                         }
                     };
-                    //Kompletteringpanel is always enabled
+                    //Kompletteringpanel is enabled for all certificate types except ag-certificates
                     if (ViewState.cert.typ !== 'ag114' && ViewState.cert.typ !== 'ag7804') {
                         panelConfig.tabs.push({
                             id: 'wc-komplettering-read-only-panel-tab',


### PR DESCRIPTION
Accompanying additions in common for read-only views of AG7804 and AG1-14. Small addition for not showing kompletterings-tab for ag-intyg (since ag-intyg don't have kompletteringar). This jira also has code additions in rehabstod and intygstjanst.
