### PR TITLE
INTYGFV-12459: Removal of duplicate text-ids in db text-xml

### DIFF
--- a/sos/db/src/main/resources/META-INF/resources/webjars/db/webcert/views/utkast/dbUtkastConfig.v1.factory.js
+++ b/sos/db/src/main/resources/META-INF/resources/webjars/db/webcert/views/utkast/dbUtkastConfig.v1.factory.js
@@ -83,7 +83,7 @@ angular.module('db').factory('db.UtkastConfigFactory.v1',
                             type: 'ue-radiogroup',
                             modelProp: 'undersokningYttre',
                             choices: [
-                                {label:'DETALJER_UNDERSOKNING.JA.RBK', id:'JA'},
+                                {label:'SVAR_JA.RBK', id:'JA'},
                                 {label:'DETALJER_UNDERSOKNING.UNDERSOKNING_SKA_GORAS.RBK', id:'UNDERSOKNING_SKA_GORAS'},
                                 {label:'DETALJER_UNDERSOKNING.UNDERSOKNING_GJORT_KORT_FORE_DODEN.RBK', id:'UNDERSOKNING_GJORT_KORT_FORE_DODEN'}
                             ],


### PR DESCRIPTION
This jira gave specific info about what to do. In DB text-xml (in refdata):
1. Remove the following three:
    \<text id="DFR_6.1.SVA_1"\>Ja\</text\>
    \<text id="DFR_6.1.SVA_2"\>Nej, rättsmedicinsk undersökning ska göras\</text\>
    \<text id="DFR_6.1.SVA_3"\>Nej, den avlidne undersökt kort före döden\</text\>

2. And replace DETALJER_UNDERSOKNING.JA.RBK with SVAR_JA.RBK

In addition, to have the DB working properly again, I had to update src/main/resources/texts/texter_DB_v1.0.xml (in common) to make the the label use the renamed text. After this change the db-form appears to work as before.