### PR TITLE
INTYGFV-14158: When downloading pdfs, always open the download url in…

### DIFF
--- a/web/src/main/resources/META-INF/resources/webjars/common/webcert/intyg/intygHeader/wcIntygButtonBar/wcIntygButtonBar.directive.js
+++ b/web/src/main/resources/META-INF/resources/webjars/common/webcert/intyg/intygHeader/wcIntygButtonBar/wcIntygButtonBar.directive.js
@@ -217,7 +217,7 @@ angular.module('common').directive('wcIntygButtonBar', ['$rootScope', '$timeout'
                                 templateUrl: '/app/partials/employee-print-dialog.html',
                                 model: {patient: patient},
                                 button1click: function(modalInstance) {
-                                    window.open(CommonIntygViewState.intygProperties.pdfUrl + '/arbetsgivarutskrift', '_self');
+                                    window.open(CommonIntygViewState.intygProperties.pdfUrl + '/arbetsgivarutskrift', '_blank');
                                     modalInstance.close();
                                 },
                                 button2click: function(modalInstance) {
@@ -236,7 +236,7 @@ angular.module('common').directive('wcIntygButtonBar', ['$rootScope', '$timeout'
                                 templateUrl: '/app/partials/sekretessmarkerad-print-dialog.html',
                                 model: {patient: patient},
                                 button1click: function(modalInstance) {
-                                    window.open(CommonIntygViewState.intygProperties.pdfUrl, '_self');
+                                    window.open(CommonIntygViewState.intygProperties.pdfUrl, '_blank');
                                     modalInstance.close();
                                 },
                                 button2click: function(modalInstance) {
@@ -248,7 +248,7 @@ angular.module('common').directive('wcIntygButtonBar', ['$rootScope', '$timeout'
                             });
                         } else {
                             // Om patienten ej är sekretessmarkerad, skriv ut direkt.
-                            window.open(CommonIntygViewState.intygProperties.pdfUrl, '_self');
+                            window.open(CommonIntygViewState.intygProperties.pdfUrl, '_blank');
                         }
                     };
                     var onNotFoundOrError = function() {

--- a/web/src/main/resources/META-INF/resources/webjars/common/webcert/utkast/utkastHeader/wcUtkastButtonBar/wcUtkastButtonBar.directive.js
+++ b/web/src/main/resources/META-INF/resources/webjars/common/webcert/utkast/utkastHeader/wcUtkastButtonBar/wcUtkastButtonBar.directive.js
@@ -133,7 +133,7 @@ angular.module('common').directive('wcUtkastButtonBar', ['$log', '$stateParams',
 
                     var onPatientFound = function(patient) {
                         if (!patient.sekretessmarkering) {
-                            window.open(CommonViewState.intyg.pdfUrl, '_self');
+                            window.open(CommonViewState.intyg.pdfUrl, '_blank');
                         } else {
                             // Visa infodialog för vanlig utskrift där patienten är sekretessmarkerad.
                             dialogService.showDialog({
@@ -142,7 +142,7 @@ angular.module('common').directive('wcUtkastButtonBar', ['$log', '$stateParams',
                                 templateUrl: '/app/partials/sekretessmarkerad-print-dialog.html',
                                 model: {patient: patient},
                                 button1click: function(modalInstance) {
-                                    window.open(CommonViewState.intyg.pdfUrl, '_self');
+                                    window.open(CommonViewState.intyg.pdfUrl, '_blank');
                                     modalInstance.close();
                                 },
                                 button2click: function(modalInstance) {


### PR DESCRIPTION
… a new tab. This is to ensure that the user isn't logged out in DJUPINTEGRATION because it is leaving the Webcert-client for a brief moment. Exact behaviour is dependent on the EHR and what browser-technology is used in the integration with Webcert. Only some experiences being logged out when printing.