### PR TITLE
BUILDENV: Deactivate parallel workers when building. This is a potent…

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 org.gradle.jvmargs=-Xmx2048m
-org.gradle.parallel=true
+org.gradle.parallel=false
 org.gradle.workers.max=3


### PR DESCRIPTION
…ial work-around for a Nexus upload issue.