### PR TITLE
INTYGFV-14983: Fixed issue with spacing regarding DB/DOI texts.

### DIFF
--- a/services/src/main/java/se/inera/intyg/common/services/texts/DefaultCertificateTextProvider.java
+++ b/services/src/main/java/se/inera/intyg/common/services/texts/DefaultCertificateTextProvider.java
@@ -67,7 +67,7 @@ public final class DefaultCertificateTextProvider implements CertificateTextProv
         String result;
         result = stringBuilder.toString().replaceAll("^\n+|^\\s+", "");
         result = result.replaceAll("\n\n+", "**");
-        result = result.replaceAll("\n|\t", "");
+        result = result.replaceAll("\t", "");
         result = result.replaceAll("\\s\\s+", " ");
         result = result.replaceAll("\\*\\*", "\n\n");
         result = result.replaceAll("\n\n\\s", "\n\n");


### PR DESCRIPTION
Solved by removing the replacement of \n. This seems to be intended for removing tabs in text since no tests are affected by this change. Also checked how other texts are affected by this change and could not spot a scenario where this will cause regression.