### PR TITLE
INTYGFV-15039: Decorated validationsErrors related to QuestionUnderlag with questionId in InternalDraftValidatorImpl.

### DIFF
--- a/fk/luae_na/src/main/java/se/inera/intyg/common/luae_na/v1/validator/InternalDraftValidatorImpl.java
+++ b/fk/luae_na/src/main/java/se/inera/intyg/common/luae_na/v1/validator/InternalDraftValidatorImpl.java
@@ -47,6 +47,7 @@ import static se.inera.intyg.common.fkparent.model.converter.RespConstants.UNDER
 import static se.inera.intyg.common.fkparent.model.converter.RespConstants.UNDERLAG_SVAR_JSON_ID_4;
 import static se.inera.intyg.common.luae_na.v1.model.converter.RespConstants.AKTIVITETSBEGRANSNING_DELSVAR_ID_17;
 import static se.inera.intyg.common.luae_na.v1.model.converter.RespConstants.SJUKDOMSFORLOPP_DELSVAR_ID_5;
+import static se.inera.intyg.common.luae_na.v1.model.converter.RespConstants.UNDERLAG_TYP_DELSVAR_ID_4;
 
 import com.google.common.base.Strings;
 import java.time.LocalDate;
@@ -185,26 +186,28 @@ public class InternalDraftValidatorImpl implements InternalDraftValidator<Luaena
             ValidatorUtil.addValidationErrorWithQuestionId(validationMessages, CATEGORY_GRUNDFORMU, UNDERLAGFINNS_SVAR_JSON_ID_3,
                 ValidationMessageType.EMPTY, UNDERLAGFINNS_DELSVAR_ID_3);
         } else if (utlatande.getUnderlagFinns() && utlatande.getUnderlag().isEmpty()) {
-            ValidatorUtil.addValidationError(validationMessages, CATEGORY_GRUNDFORMU, UNDERLAG_SVAR_JSON_ID_4,
-                ValidationMessageType.EMPTY);
+            ValidatorUtil.addValidationErrorWithQuestionId(validationMessages, CATEGORY_GRUNDFORMU, UNDERLAG_SVAR_JSON_ID_4,
+                ValidationMessageType.EMPTY, UNDERLAG_TYP_DELSVAR_ID_4);
         } else if (!utlatande.getUnderlagFinns() && !utlatande.getUnderlag().isEmpty()) {
             // R6
-            ValidatorUtil.addValidationError(validationMessages, CATEGORY_GRUNDFORMU, UNDERLAGFINNS_SVAR_JSON_ID_3,
+            ValidatorUtil.addValidationErrorWithQuestionId(validationMessages, CATEGORY_GRUNDFORMU, UNDERLAGFINNS_SVAR_JSON_ID_3,
                 ValidationMessageType.OTHER,
-                "luae_na.validation.underlagfinns.incorrect_combination");
+                "luae_na.validation.underlagfinns.incorrect_combination", UNDERLAG_TYP_DELSVAR_ID_4);
         }
 
         if (utlatande.getUnderlag().size() > MAX_UNDERLAG) {
-            ValidatorUtil.addValidationError(validationMessages, CATEGORY_GRUNDFORMU, UNDERLAG_SVAR_JSON_ID_4, ValidationMessageType.OTHER,
-                "luae_na.validation.underlag.too_many");
+            ValidatorUtil.addValidationErrorWithQuestionId(validationMessages, CATEGORY_GRUNDFORMU, UNDERLAG_SVAR_JSON_ID_4,
+                ValidationMessageType.OTHER,
+                "luae_na.validation.underlag.too_many", UNDERLAG_TYP_DELSVAR_ID_4);
         }
         for (int i = 0; i < utlatande.getUnderlag().size(); i++) {
             Underlag underlag = utlatande.getUnderlag().get(i);
             // Alla underlagstyper är godkända här utom Underlag från skolhälsovård
             if (underlag.getTyp() == null) {
-                ValidatorUtil.addValidationError(validationMessages, CATEGORY_GRUNDFORMU, UNDERLAG_SVAR_JSON_ID_4 + "[" + i + "].typ",
+                ValidatorUtil.addValidationErrorWithQuestionId(validationMessages, CATEGORY_GRUNDFORMU,
+                    UNDERLAG_SVAR_JSON_ID_4 + "[" + i + "].typ",
                     ValidationMessageType.EMPTY,
-                    "luae_na.validation.underlag.missing");
+                    "luae_na.validation.underlag.missing", UNDERLAG_TYP_DELSVAR_ID_4);
             } else if (!underlag.getTyp().getId().equals(Underlag.UnderlagsTyp.NEUROPSYKIATRISKT_UTLATANDE.getId())
                 && !underlag.getTyp().getId().equals(Underlag.UnderlagsTyp.UNDERLAG_FRAN_HABILITERINGEN.getId())
                 && !underlag.getTyp().getId().equals(Underlag.UnderlagsTyp.UNDERLAG_FRAN_ARBETSTERAPEUT.getId())
@@ -216,32 +219,32 @@ public class InternalDraftValidatorImpl implements InternalDraftValidator<Luaena
                 && !underlag.getTyp().getId().equals(Underlag.UnderlagsTyp.UTREDNING_AV_ANNAN_SPECIALISTKLINIK.getId())
                 && !underlag.getTyp().getId().equals(Underlag.UnderlagsTyp.UTREDNING_FRAN_VARDINRATTNING_UTOMLANDS.getId())
                 && !underlag.getTyp().getId().equals(Underlag.UnderlagsTyp.OVRIGT.getId())) {
-                ValidatorUtil.addValidationError(validationMessages, CATEGORY_GRUNDFORMU,
+                ValidatorUtil.addValidationErrorWithQuestionId(validationMessages, CATEGORY_GRUNDFORMU,
                     UNDERLAG_SVAR_JSON_ID_4 + "[" + i + "].typ",
                     ValidationMessageType.INVALID_FORMAT,
-                    "luae_na.validation.underlag.incorrect_format");
+                    "luae_na.validation.underlag.incorrect_format", UNDERLAG_TYP_DELSVAR_ID_4);
             }
             if (underlag.getDatum() == null) {
-                ValidatorUtil.addValidationError(validationMessages, CATEGORY_GRUNDFORMU,
+                ValidatorUtil.addValidationErrorWithQuestionId(validationMessages, CATEGORY_GRUNDFORMU,
                     UNDERLAG_SVAR_JSON_ID_4 + "[" + i + "].datum", ValidationMessageType.EMPTY,
-                    "luae_na.validation.underlag.date.missing");
+                    "luae_na.validation.underlag.date.missing", UNDERLAG_TYP_DELSVAR_ID_4);
             } else {
                 ValidatorUtil.validateDateAndCheckIfFuture(underlag.getDatum(), validationMessages, CATEGORY_GRUNDFORMU,
-                    UNDERLAG_SVAR_JSON_ID_4 + "[" + i + "].datum", "common.validation.c-06");
+                    UNDERLAG_SVAR_JSON_ID_4 + "[" + i + "].datum", "common.validation.c-06", UNDERLAG_TYP_DELSVAR_ID_4);
             }
             if (Strings.nullToEmpty(underlag.getHamtasFran()).trim().isEmpty()) {
-                ValidatorUtil.addValidationError(validationMessages, CATEGORY_GRUNDFORMU,
+                ValidatorUtil.addValidationErrorWithQuestionId(validationMessages, CATEGORY_GRUNDFORMU,
                     UNDERLAG_SVAR_JSON_ID_4 + "[" + i + "].hamtasFran",
                     ValidationMessageType.EMPTY,
-                    "luae_na.validation.underlag.hamtas-fran.missing");
+                    "luae_na.validation.underlag.hamtas-fran.missing", UNDERLAG_TYP_DELSVAR_ID_4);
             }
         }
 
         if (utlatande.getUnderlag().size() > 1 && !validateFirstUnderlagIsPresent(utlatande.getUnderlag())) {
-            ValidatorUtil.addValidationError(validationMessages, CATEGORY_GRUNDFORMU,
+            ValidatorUtil.addValidationErrorWithQuestionId(validationMessages, CATEGORY_GRUNDFORMU,
                 UNDERLAG_SVAR_JSON_ID_4 + "[0]",
                 ValidationMessageType.INCORRECT_COMBINATION,
-                "common.validation.c-05");
+                "common.validation.c-05", UNDERLAG_TYP_DELSVAR_ID_4);
         }
     }
 

--- a/fk/luae_na/src/test/java/se/inera/intyg/common/luae_na/v1/validator/InternalDraftValidatorTest.java
+++ b/fk/luae_na/src/test/java/se/inera/intyg/common/luae_na/v1/validator/InternalDraftValidatorTest.java
@@ -22,13 +22,14 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
-import static se.inera.intyg.common.luae_na.v1.model.converter.RespConstants.AKTIVITETSBEGRANSNING_DELSVAR_ID_17;
 import static se.inera.intyg.common.fkparent.model.converter.RespConstants.GRUNDFORMEDICINSKTUNDERLAG_ANNANBESKRIVNING_DELSVAR_ID_1;
 import static se.inera.intyg.common.fkparent.model.converter.RespConstants.GRUNDFORMEDICINSKTUNDERLAG_TYP_DELSVAR_ID_1;
 import static se.inera.intyg.common.fkparent.model.converter.RespConstants.KANNEDOM_DELSVAR_ID_2;
 import static se.inera.intyg.common.fkparent.model.converter.RespConstants.UNDERLAGFINNS_DELSVAR_ID_3;
-import static se.inera.intyg.common.luae_na.v1.model.converter.RespConstants.SJUKDOMSFORLOPP_DELSVAR_ID_5;
+import static se.inera.intyg.common.luae_na.v1.model.converter.RespConstants.AKTIVITETSBEGRANSNING_DELSVAR_ID_17;
 import static se.inera.intyg.common.luae_na.v1.model.converter.RespConstants.FUNKTIONSNEDSATTNING_CATEGORY_ID;
+import static se.inera.intyg.common.luae_na.v1.model.converter.RespConstants.SJUKDOMSFORLOPP_DELSVAR_ID_5;
+import static se.inera.intyg.common.luae_na.v1.model.converter.RespConstants.UNDERLAG_TYP_DELSVAR_ID_4;
 
 import java.lang.reflect.Field;
 import java.time.LocalDate;
@@ -275,6 +276,7 @@ public class InternalDraftValidatorTest {
         assertEquals("grundformu", res.getValidationErrors().get(0).getCategory());
         assertEquals("underlag", res.getValidationErrors().get(0).getField());
         assertEquals(ValidationMessageType.EMPTY, res.getValidationErrors().get(0).getType());
+        assertEquals(UNDERLAG_TYP_DELSVAR_ID_4, res.getValidationErrors().get(0).getQuestionId());
     }
 
     @Test
@@ -289,6 +291,7 @@ public class InternalDraftValidatorTest {
         assertEquals(1, res.getValidationErrors().size());
         assertEquals("luae_na.validation.underlagfinns.incorrect_combination", res.getValidationErrors().get(0).getMessage());
         assertEquals(ValidationMessageType.OTHER, res.getValidationErrors().get(0).getType());
+        assertEquals(UNDERLAG_TYP_DELSVAR_ID_4, res.getValidationErrors().get(0).getQuestionId());
     }
 
     @Test
@@ -328,6 +331,7 @@ public class InternalDraftValidatorTest {
         assertEquals(1, res.getValidationErrors().size());
         assertEquals("luae_na.validation.underlag.too_many", res.getValidationErrors().get(0).getMessage());
         assertEquals(ValidationMessageType.OTHER, res.getValidationErrors().get(0).getType());
+        assertEquals(UNDERLAG_TYP_DELSVAR_ID_4, res.getValidationErrors().get(0).getQuestionId());
     }
 
     @Test
@@ -342,8 +346,10 @@ public class InternalDraftValidatorTest {
         assertEquals(2, res.getValidationErrors().size());
         assertEquals("luae_na.validation.underlag.date.missing", res.getValidationErrors().get(0).getMessage());
         assertEquals(ValidationMessageType.EMPTY, res.getValidationErrors().get(0).getType());
+        assertEquals(UNDERLAG_TYP_DELSVAR_ID_4, res.getValidationErrors().get(0).getQuestionId());
         assertEquals("luae_na.validation.underlag.hamtas-fran.missing", res.getValidationErrors().get(1).getMessage());
         assertEquals(ValidationMessageType.EMPTY, res.getValidationErrors().get(1).getType());
+        assertEquals(UNDERLAG_TYP_DELSVAR_ID_4, res.getValidationErrors().get(1).getQuestionId());
     }
 
     @Test


### PR DESCRIPTION
Since we already synced with frontend that we are using field to locate which component the error is related to, we only need to decorate validationErrors with questionId in backend to make validation work?