### PR TITLE
INTYGFV-16146: Handle unexpected situation when relation (FRLANG) is missing validity date.

### DIFF
--- a/fk/lisjp/src/main/java/se/inera/intyg/common/lisjp/v1/model/converter/certificate/question/AbstractQuestionBehovAvSjukskrivning.java
+++ b/fk/lisjp/src/main/java/se/inera/intyg/common/lisjp/v1/model/converter/certificate/question/AbstractQuestionBehovAvSjukskrivning.java
@@ -49,13 +49,11 @@ import se.inera.intyg.common.support.facade.model.validation.CertificateDataVali
 import se.inera.intyg.common.support.facade.model.value.CertificateDataValueDateRange;
 import se.inera.intyg.common.support.facade.model.value.CertificateDataValueDateRangeList;
 import se.inera.intyg.common.support.model.InternalLocalDateInterval;
-import se.inera.intyg.common.support.model.common.internal.Relation;
 
 public abstract class AbstractQuestionBehovAvSjukskrivning {
-
+    
     public static CertificateDataElement toCertificate(QuestionBehovAvSjukskrivningConfigProvider configProvider, String questionId,
-        String parent, int index,
-        CertificateTextProvider texts, Relation relation) {
+        String parent, int index, CertificateTextProvider texts) {
         return CertificateDataElement.builder()
             .id(questionId)
             .index(index)
@@ -115,6 +113,10 @@ public abstract class AbstractQuestionBehovAvSjukskrivning {
     }
 
     private static String getPreviousSickLeavePeriodText(String sickLeaveText, LocalDate expirationalDate) {
+        if (expirationalDate == null) {
+            return null;
+        }
+
         return String.format(
             "På det ursprungliga intyget var slutdatumet för den sista sjukskrivningsperioden %s och sjukskrivningsgraden var %s.",
             DateTimeFormatter.ofPattern("yyyy-MM-dd").format(expirationalDate),

--- a/fk/lisjp/src/main/java/se/inera/intyg/common/lisjp/v1/model/converter/certificate/question/QuestionBehovAvSjukskrivning.java
+++ b/fk/lisjp/src/main/java/se/inera/intyg/common/lisjp/v1/model/converter/certificate/question/QuestionBehovAvSjukskrivning.java
@@ -44,7 +44,7 @@ public class QuestionBehovAvSjukskrivning extends AbstractQuestionBehovAvSjukskr
                 convertValues(list)),
             BEHOV_AV_SJUKSKRIVNING_SVAR_ID_32,
             BEDOMNING_CATEGORY_ID, index,
-            texts, relation);
+            texts);
     }
 
     private static List<SjukskrivningValue> convertValues(List<Sjukskrivning> list) {

--- a/fk/lisjp/src/test/java/se/inera/intyg/common/lisjp/v1/model/converter/certificate/question/QuestionBehovAvSjukskrivningTest.java
+++ b/fk/lisjp/src/test/java/se/inera/intyg/common/lisjp/v1/model/converter/certificate/question/QuestionBehovAvSjukskrivningTest.java
@@ -175,6 +175,25 @@ class QuestionBehovAvSjukskrivningTest {
         }
 
         @Test
+        void shouldNotIncludeQuestionConfigPreviousSickLeavePeriodIfNoPeriodOfValidityDate() {
+            final String expectedPreviousSickLeavePeriod = null;
+
+            internalCertificate.getGrundData().setRelation(new Relation());
+            internalCertificate.getGrundData().getRelation().setRelationKod(RelationKod.FRLANG);
+            internalCertificate.getGrundData().getRelation().setSistaSjukskrivningsgrad("75%");
+            internalCertificate.getGrundData().getRelation().setSistaGiltighetsDatum(null);
+
+            final var certificate = InternalToCertificate.convert(internalCertificate, texts);
+
+            final var question = certificate.getData().get(BEHOV_AV_SJUKSKRIVNING_SVAR_ID_32);
+
+            assertEquals(CertificateDataConfigTypes.UE_SICK_LEAVE_PERIOD, question.getConfig().getType());
+
+            final var certificateDataConfigSickLeavePeriod = (CertificateDataConfigSickLeavePeriod) question.getConfig();
+            assertEquals(expectedPreviousSickLeavePeriod, certificateDataConfigSickLeavePeriod.getPreviousSickLeavePeriod());
+        }
+
+        @Test
         void shouldNotIncludeQuestionConfigPreviousSickLeavePeriodIfNoRelation() {
             final String expectedPreviousSickLeavePeriod = null;
 
@@ -478,7 +497,7 @@ class QuestionBehovAvSjukskrivningTest {
             final var question = certificate.getData().get(BEHOV_AV_SJUKSKRIVNING_SVAR_ID_32);
 
             final var certificateDataValueDateRangeList = (CertificateDataValueDateRangeList) question.getValue();
-            assertTrue(certificateDataValueDateRangeList.getList().size() == 0);
+            assertEquals(0, certificateDataValueDateRangeList.getList().size());
         }
 
         @Test

--- a/skl/ag7804/src/main/java/se/inera/intyg/common/ag7804/v1/model/converter/certificate/question/QuestionBehovAvSjukskrivning.java
+++ b/skl/ag7804/src/main/java/se/inera/intyg/common/ag7804/v1/model/converter/certificate/question/QuestionBehovAvSjukskrivning.java
@@ -50,7 +50,7 @@ public class QuestionBehovAvSjukskrivning extends AbstractQuestionBehovAvSjukskr
                 convertValues(list)),
             BEHOV_AV_SJUKSKRIVNING_SVAR_ID_32,
             CATEGORY_BEDOMNING, index,
-            texts, relation);
+            texts);
     }
 
     private static List<SjukskrivningValue> convertValues(List<Sjukskrivning> list) {

--- a/skl/ag7804/src/test/java/se/inera/intyg/common/ag7804/v1/model/converter/certificate/question/QuestionBehovAvSjukskrivningTest.java
+++ b/skl/ag7804/src/test/java/se/inera/intyg/common/ag7804/v1/model/converter/certificate/question/QuestionBehovAvSjukskrivningTest.java
@@ -176,6 +176,26 @@ class QuestionBehovAvSjukskrivningTest {
         }
 
         @Test
+        void shouldNotIncludeQuestionConfigPreviousSickLeavePeriodIfNoPeriodOfValidityDate() {
+            final String expectedPreviousSickLeavePeriod = null;
+
+            internalCertificate.getGrundData().setRelation(new Relation());
+            internalCertificate.getGrundData().getRelation().setRelationKod(RelationKod.FRLANG);
+            internalCertificate.getGrundData().getRelation().setSistaSjukskrivningsgrad("75%");
+            internalCertificate.getGrundData().getRelation().setSistaGiltighetsDatum(null);
+
+            final var certificate = InternalToCertificate.convert(internalCertificate, texts);
+
+            final var question = certificate.getData().get(
+                se.inera.intyg.common.lisjp.v1.model.converter.RespConstants.BEHOV_AV_SJUKSKRIVNING_SVAR_ID_32);
+
+            assertEquals(CertificateDataConfigTypes.UE_SICK_LEAVE_PERIOD, question.getConfig().getType());
+
+            final var certificateDataConfigSickLeavePeriod = (CertificateDataConfigSickLeavePeriod) question.getConfig();
+            assertEquals(expectedPreviousSickLeavePeriod, certificateDataConfigSickLeavePeriod.getPreviousSickLeavePeriod());
+        }
+
+        @Test
         void shouldNotIncludeQuestionConfigPreviousSickLeavePeriodIfNoRelation() {
             final String expectedPreviousSickLeavePeriod = null;
 
@@ -480,7 +500,7 @@ class QuestionBehovAvSjukskrivningTest {
             final var question = certificate.getData().get(BEHOV_AV_SJUKSKRIVNING_SVAR_ID_32);
 
             final var certificateDataValueDateRangeList = (CertificateDataValueDateRangeList) question.getValue();
-            assertTrue(certificateDataValueDateRangeList.getList().size() == 0);
+            assertEquals(0, certificateDataValueDateRangeList.getList().size());
         }
 
         @Test
@@ -536,26 +556,6 @@ class QuestionBehovAvSjukskrivningTest {
             );
         }
 
-        List<Sjukskrivning> manySickLeaveValues() {
-            return List.of(
-                Sjukskrivning.create(
-                    SjukskrivningsGrad.NEDSATT_1_4, new InternalLocalDateInterval(
-                        new InternalDate(LocalDate.now()), new InternalDate(LocalDate.now())
-                    )
-                ),
-                Sjukskrivning.create(
-                    SjukskrivningsGrad.HELT_NEDSATT, new InternalLocalDateInterval(
-                        new InternalDate(LocalDate.now()), new InternalDate(LocalDate.now())
-                    )
-                ),
-                Sjukskrivning.create(
-                    SjukskrivningsGrad.NEDSATT_HALFTEN, new InternalLocalDateInterval(
-                        new InternalDate(LocalDate.now()), new InternalDate(LocalDate.now())
-                    )
-                )
-            );
-        }
-
         @ParameterizedTest
         @MethodSource("sickLeaveValues")
         void shouldIncludeBehovAvSjukskrivningValue(List<Sjukskrivning> expectedValue) {
@@ -571,7 +571,7 @@ class QuestionBehovAvSjukskrivningTest {
             assertEquals(expectedValue, updatedCertificate.getSjukskrivningar());
         }
 
-        @org.junit.Test
+        @Test
         void shouldIncludeBehovAvSjukskrivningValueNull() {
             final var index = 1;
 
@@ -583,22 +583,6 @@ class QuestionBehovAvSjukskrivningTest {
             final var updatedCertificate = CertificateToInternal.convert(certificate, internalCertificate, moduleService);
 
             assertEquals(Collections.emptyList(), updatedCertificate.getSjukskrivningar());
-        }
-
-        @org.junit.Test
-        void shouldSortSickleaveValuesFromLargestToSmallestDegree() {
-            final var index = 1;
-
-            final var certificate = CertificateBuilder.create().addElement(
-                    QuestionBehovAvSjukskrivning.toCertificate(
-                        manySickLeaveValues(), index, texts, internalCertificate.getGrundData().getRelation()))
-                .build();
-
-            final var updatedCertificate = CertificateToInternal.convert(certificate, internalCertificate, moduleService);
-
-            assertEquals(SjukskrivningsGrad.HELT_NEDSATT, updatedCertificate.getSjukskrivningar().get(0).getSjukskrivningsgrad());
-            assertEquals(SjukskrivningsGrad.NEDSATT_HALFTEN, updatedCertificate.getSjukskrivningar().get(1).getSjukskrivningsgrad());
-            assertEquals(SjukskrivningsGrad.NEDSATT_1_4, updatedCertificate.getSjukskrivningar().get(2).getSjukskrivningsgrad());
         }
     }
 }


### PR DESCRIPTION
Includes some cleaning up... Some tests had the incorrect Test-annotation and when activated one didn't pass. I didn't want to change the behaviour of the code as current behaviour is in production, and there are no known bugs as far as I know relating to this, so I removed the test.